### PR TITLE
PCF2131 clock out, reset and OTP refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 ehthumbs.db
 Thumbs.db
 
+# IDE  files #
+##############
+.idea

--- a/src/PCF2131_base.cpp
+++ b/src/PCF2131_base.cpp
@@ -171,3 +171,8 @@ void PCF2131_base::set_clock_out(clock_out_frequency freq)
 {
     _bit_op8(CLKOUT_ctl, ~0b00000111, freq);
 }
+
+void PCF2131_base::reset()
+{
+    _reg_w(SR_Reset, 0b00101100);
+}

--- a/src/PCF2131_base.cpp
+++ b/src/PCF2131_base.cpp
@@ -176,3 +176,9 @@ void PCF2131_base::reset()
 {
     _reg_w(SR_Reset, 0b00101100);
 }
+
+void PCF2131_base::otp_refresh()
+{
+    _bit_op8(CLKOUT_ctl, ~0b00100000, 0b00000000);
+    _bit_op8(CLKOUT_ctl, ~0b00100000, 0b00100000);
+}

--- a/src/PCF2131_base.cpp
+++ b/src/PCF2131_base.cpp
@@ -166,3 +166,8 @@ void PCF2131_base::periodic_interrupt_enable( periodic_int_select sel, int int_s
 	_bit_op8( Control_1, ~0x03, v );
 	_bit_op8( int_mask_reg[ int_sel ][ 0 ], ~0x30, ~(v << 4) );
 }
+
+void PCF2131_base::set_clock_out(clock_out_frequency freq)
+{
+    _bit_op8(CLKOUT_ctl, ~0b00000111, freq);
+}

--- a/src/PCF2131_base.cpp
+++ b/src/PCF2131_base.cpp
@@ -88,7 +88,7 @@ void PCF2131_base::alarm_disable( void )
 	_bit_op8( Control_2, ~0x02, 0x00 );
 }
 
-void PCF2131_base::timestamp( int num, timestanp_setting ts_setting, int int_sel )
+void PCF2131_base::timestamp( int num, timestamp_setting ts_setting, int int_sel )
 {
 	const int r_ofst	= 7;
 	const int fst		= ts_setting ? 0x80 : 0x00;

--- a/src/RTC_NXP.h
+++ b/src/RTC_NXP.h
@@ -115,7 +115,7 @@ protected:
 /** PCF2131_base class
  *	
  *	A base class for PCF2131
- *	Implementing register operation with abstarcted interface
+ *	Implementing register operation with abstracted interface
  *
  *  @class PCF2131_base
  */
@@ -149,6 +149,18 @@ public:
 		LAST,
 		FIRST,
 	};
+    /** Clock output frequency descriptor */
+    enum clock_out_frequency
+    {
+        FREQ_32768_HZ,
+        FREQ_16384_HZ,
+        FREQ_8192_HZ,
+        FREQ_4096_HZ,
+        FREQ_2048_HZ,
+        FREQ_1024_HZ,
+        FREQ_1_HZ,
+        FREQ_DISABLE
+    };
 
 	/** Constructor */
 	PCF2131_base();
@@ -232,6 +244,12 @@ public:
 	 * @param int_sel Interrupt output selector. ) for INT_A, 1 for INT_B
 	 */
 	void periodic_interrupt_enable( periodic_int_select sel, int int_sel = 0 );
+
+    /** Set clock output (CLKOUT)
+	 *
+	 * @param freq choose desired clock output (CLKOUT) frequency in 'enum clock_out_frequency'
+	 */
+    void set_clock_out(clock_out_frequency freq);
 
 protected:
 	/** Proxy method for interface  (pure virtual method) */

--- a/src/RTC_NXP.h
+++ b/src/RTC_NXP.h
@@ -145,7 +145,7 @@ public:
 		EVERY_MINUTE,
 	};
 	/** Timestamp setting descriptor */
-	enum timestanp_setting {
+	enum timestamp_setting {
 		LAST,
 		FIRST,
 	};
@@ -206,10 +206,10 @@ public:
 	/** Timestamp setting
 	 * 
 	 * @param num timestamp number: 1~4
-	 * @param ts_setting event recording option. Choose LAST or FIRST in 'enum timestanp_setting'
+	 * @param ts_setting event recording option. Choose LAST or FIRST in 'enum timestamp_setting'
 	 * @param int_sel Interrupt output selector. ) for INT_A, 1 for INT_B
 	 */
-	void timestamp( int num, timestanp_setting ts_setting, int int_sel = 0 );
+	void timestamp( int num, timestamp_setting ts_setting, int int_sel = 0 );
 
 	/** Getting timestamp info
 	 * 
@@ -306,7 +306,7 @@ public:
 		EVERY_MINUTE,
 	};
 	/** Timestamp setting descriptor */
-	enum timestanp_setting {
+	enum timestamp_setting {
 		LAST,
 		FIRST,
 	};
@@ -370,10 +370,10 @@ public:
 	/** Timestamp setting
 	 * 
 	 * @param num timestamp number: 1~4
-	 * @param ts_setting event recording option. Choose LAST or FIRST in 'enum timestanp_setting'
+	 * @param ts_setting event recording option. Choose LAST or FIRST in 'enum timestamp_setting'
 	 * @param int_sel Interrupt output selector. ) for INT_A, 1 for INT_B
 	 */
-	void timestamp( int num, timestanp_setting ts_setting, int int_sel = 0 );
+	void timestamp( int num, timestamp_setting ts_setting, int int_sel = 0 );
 
 	/** Getting timestamp info
 	 * 
@@ -592,7 +592,7 @@ public:
 		EVERY_MINUTE,
 	};
 	/** Timestamp setting descriptor */
-	enum timestanp_setting {
+	enum timestamp_setting {
 		LAST,
 		FIRST,
 	};
@@ -656,10 +656,10 @@ public:
 	/** Timestamp setting
 	 * 
 	 * @param num timestamp number: 1~4
-	 * @param ts_setting event recording option. Choose LAST or FIRST in 'enum timestanp_setting'
+	 * @param ts_setting event recording option. Choose LAST or FIRST in 'enum timestamp_setting'
 	 * @param int_sel Interrupt output selector. ) for INT_A, 1 for INT_B
 	 */
-	void timestamp( int num, timestanp_setting ts_setting, int int_sel = 0 );
+	void timestamp( int num, timestamp_setting ts_setting, int int_sel = 0 );
 
 	/** Getting timestamp info
 	 * 

--- a/src/RTC_NXP.h
+++ b/src/RTC_NXP.h
@@ -255,6 +255,10 @@ public:
 	 */
     void reset();
 
+    /** Perform OTP refresh (loads factory-provided calibration data stored in EPROM)
+	 */
+    void otp_refresh();
+
 protected:
 	/** Proxy method for interface  (pure virtual method) */
 	virtual void _reg_w( uint8_t reg, uint8_t *vp, int len )	= 0;

--- a/src/RTC_NXP.h
+++ b/src/RTC_NXP.h
@@ -251,6 +251,10 @@ public:
 	 */
     void set_clock_out(clock_out_frequency freq);
 
+    /** Trigger software reset
+	 */
+    void reset();
+
 protected:
 	/** Proxy method for interface  (pure virtual method) */
 	virtual void _reg_w( uint8_t reg, uint8_t *vp, int len )	= 0;


### PR DESCRIPTION
I added support for clock out for the PCF2131, as described in the datasheet:

![image](https://github.com/user-attachments/assets/2586a22c-6b95-436b-8a75-1f6475628b14)

You can test it with something like `rtc.set_clock_out(PCF2131_I2C::FREQ_1_HZ);`. You can use a simple multimeter to verify the 1Hz square wave on the CLKOUT pin. An oscilloscope can be used to validate the higher frequency waves.

I also added support for the OTP refresh for the PCF2131,  as described in the datasheet:

![image](https://github.com/user-attachments/assets/061d401b-a22e-43f9-92d6-84e94fc712ff)

I also added support for the software reset for the PCF2131,  as described in the datasheet:

![image](https://github.com/user-attachments/assets/048e0e70-6ac6-417b-9a5c-e0d93d30243e)

After a reset, all configuration is reset to default. This means the reset can be tested by changing the configuration (e.g. CLKOUT frequency), performing a reset, and verifying that the configuration is back to default. 


Feel free to make changes to the PR if needed (e.g. method names or other things you don't like).  

